### PR TITLE
EditorCoroutineHost class creation

### DIFF
--- a/Assets/EditorCoroutines/Scripts/CoroutineHostExample.cs
+++ b/Assets/EditorCoroutines/Scripts/CoroutineHostExample.cs
@@ -1,0 +1,103 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Runtime.InteropServices;
+using UnityEditor;
+
+namespace EditorCoroutines.Examples
+{
+	public class CoroutineHostExample : EditorCoroutineHost
+	{
+		private static CoroutineHostExample _instance;
+		private static CoroutineHostExample Instance
+		{
+			get
+			{
+				if (_instance == null)
+				{
+					_instance = new CoroutineHostExample();
+				}
+
+				return _instance;
+			}
+		}
+
+		[MenuItem("Window/Coroutine Example (Host)/Start")]
+		public static void Start()
+		{
+			Instance.StartCoroutine(Instance.Example());
+		}
+
+		[MenuItem("Window/Coroutine Example (Host)/Start WWW")]
+		public static void StartWWW()
+		{
+			Instance.StartCoroutine(Instance.ExampleWWW());
+		}
+
+		[MenuItem("Window/Coroutine Example (Host)/Start Nested")]
+		public static void StartNested()
+		{
+			Instance.StartCoroutine(Instance.ExampleNested());
+		}
+
+		[MenuItem("Window/Coroutine Example (Host)/Stop")]
+		public static void Stop()
+		{
+			Instance.StopCoroutine("Example");
+		}
+		
+		[MenuItem("Window/Coroutine Example (Host)/Stop all")]
+		public static void StopAll()
+		{
+			Instance.StopAllCoroutines();
+		}
+
+		[MenuItem("Window/Coroutine Example (Host)/Also")]
+		public static void Also()
+		{
+			Instance.StopAllCoroutines();
+		}
+		
+		IEnumerator Example()
+		{
+			while (true)
+			{
+				Debug.Log("Hello EditorCoroutine!");
+				yield return new WaitForSeconds(2f);
+			}
+		}
+
+		IEnumerator ExampleWWW()
+		{
+			while (true)
+			{
+				var www = new WWW("https://unity3d.com/");
+				yield return www;
+				Debug.Log("Hello EditorCoroutine!" + www.text);
+				yield return new WaitForSeconds(2f);
+			}
+		}
+
+		IEnumerator ExampleNested()
+		{
+			while (true)
+			{
+				yield return new WaitForSeconds(2f);
+				Debug.Log("I'm not nested");
+				yield return this.StartCoroutine(ExampleNestedOneLayer());
+			}
+		}
+
+		IEnumerator ExampleNestedOneLayer()
+		{
+			yield return new WaitForSeconds(2f);
+			Debug.Log("I'm one layer nested");
+			yield return this.StartCoroutine(ExampleNestedTwoLayers());
+		}
+
+		IEnumerator ExampleNestedTwoLayers()
+		{
+			yield return new WaitForSeconds(2f);
+			Debug.Log("I'm two layers nested");
+		}
+	}
+}

--- a/Assets/EditorCoroutines/Scripts/CoroutineHostExample.cs.meta
+++ b/Assets/EditorCoroutines/Scripts/CoroutineHostExample.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 0d6db450bae660e4b9729aff2600234a
+timeCreated: 1520833265
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorCoroutines/Scripts/EditorCoroutineHost.cs
+++ b/Assets/EditorCoroutines/Scripts/EditorCoroutineHost.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+
+namespace EditorCoroutines
+{
+    public class EditorCoroutineHost
+    {
+        public EditorCoroutines.EditorCoroutine StartCoroutine(IEnumerator coroutine)
+        {
+            return EditorCoroutines.StartCoroutine(coroutine, this);
+        }
+
+        public EditorCoroutines.EditorCoroutine StartCoroutine(string methodName)
+        {
+            return EditorCoroutines.StartCoroutine(methodName, this);
+        }
+
+        public EditorCoroutines.EditorCoroutine StartCoroutine(string methodName, object value)
+        {
+            return EditorCoroutines.StartCoroutine(methodName, value, this);
+        }
+
+        public void StopCoroutine(IEnumerator coroutine)
+        {
+            EditorCoroutines.StopCoroutine(coroutine, this);
+        }
+
+        public void StopCoroutine(string methodName)
+        {
+            EditorCoroutines.StopCoroutine(methodName, this);
+        }
+
+        public void StopAllCoroutines()
+        {
+            EditorCoroutines.StopAllCoroutines(this);
+        }
+    }
+}

--- a/Assets/EditorCoroutines/Scripts/EditorCoroutineHost.cs.meta
+++ b/Assets/EditorCoroutines/Scripts/EditorCoroutineHost.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 464753e396a15ea47bb2a3588939d99a
+timeCreated: 1520833253
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. Created the EditorCoroutineHost class. This class inhabits static functions from EditorCoroutines class with a reference to itself. Intended to be used as a base class, but it is up to the user.

2. Created the CoroutineHostExample class. This class demonstrates how to use the EditorCoroutineHost class. Uses MenuItems for trigger methods.

Via inheritence, EditorCoroutineHost class allows for the quick preparation of a class that can use itself as the instance for EditorCoroutines class methods instead of relying on an editor window instance. This can be especially useful as a singleton as seen in CoroutineHostExample class.